### PR TITLE
Support for streams marked as non readable/writable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,13 @@
 'use strict';
-
 var isStream = module.exports = function (stream) {
 	return stream !== null && typeof stream === 'object' && typeof stream.pipe === 'function';
 };
-
 isStream.writable = function (stream) {
-	return isStream(stream) && typeof stream._write == 'function' && typeof stream._writableState == 'object';
+	return isStream(stream) && stream.writable !== false && typeof stream._write == 'function' && typeof stream._writableState == 'object';
 };
-
 isStream.readable = function (stream) {
-	return isStream(stream) && typeof stream._read == 'function' && typeof stream._readableState == 'object';
+	return isStream(stream) && stream.readable !== false && typeof stream._read == 'function' && typeof stream._readableState == 'object';
 };
-
 isStream.duplex = function (stream) {
 	return isStream.writable(stream) && isStream.readable(stream);
 };


### PR DESCRIPTION
Some streams (e.g. [sockets](http://nodejs.org/api/net.html#net_new_net_socket_options)) can be non readable/writable even if they have the API.

They can be detected by their `readable`/`writable` boolean properties even though I have not seen this in the docs (see [this comment](https://github.com/joyent/node/issues/8349#issuecomment-55434130)).

PS #1: I did not write test this code because I did the edition via GitHub.
PS #2: Is it normal that there is no way to create issues for this repo?
