### PR TITLE
strict comparisons, add is emitter check

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,27 @@
 'use strict';
 
+var isNodeEmitter = require('is-node-emitter');
+
 var isStream = module.exports = function (stream) {
-	return stream !== null && typeof stream === 'object' && typeof stream.pipe === 'function';
+	return isNodeEmitter(stream) && typeof stream.pipe === 'function';
 };
 
 isStream.writable = function (stream) {
-	return isStream(stream) && stream.writable !== false && typeof stream._write == 'function' && typeof stream._writableState == 'object';
+	return isStream(stream) && isWritable(stream);
 };
 
 isStream.readable = function (stream) {
-	return isStream(stream) && stream.readable !== false && typeof stream._read == 'function' && typeof stream._readableState == 'object';
+	return isStream(stream) && isReadable(stream);
 };
 
 isStream.duplex = function (stream) {
-	return isStream.writable(stream) && isStream.readable(stream);
+	return isStream(stream) && isWritable(stream) && isReadable(stream);
 };
+
+function isWritable(stream) {
+	return stream.writable !== false && typeof stream._write === 'function' && typeof stream._writableState === 'object';
+}
+
+function isReadable(stream) {
+	return stream.readable !== false && typeof stream._read === 'function' && typeof stream._readableState === 'object';
+}

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   "devDependencies": {
     "ava": "0.0.4",
     "tempfile": "^1.1.0"
+  },
+  "dependencies": {
+    "is-node-emitter": "^1.0.1"
   }
 }


### PR DESCRIPTION
- add event emitter, cuz streams are emitters
- jshint and XO linted, so it was needed to separate and clean the code
- maybe I should add and `xo`?

Call me "the strict guy", but I love this strictness and I'm trying to apply it always and anywhere. Sue me!

Cheers.
