### PR TITLE
Add support for return the `type` of stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,4 +26,11 @@ isStream.transform = stream =>
 	typeof stream._transform === 'function' &&
 	typeof stream._transformState === 'object';
 
+isStream.type = stream =>
+	isStream.transform(stream) ? 'transform' :
+		isStream.duplex(stream) ? 'duplex' :
+			isStream.writable(stream) ? 'writable' :
+				isStream.readable(stream) ? 'readable' :
+					isStream(stream) ? 'unknown' : 'no-stream';
+
 module.exports = isStream;

--- a/test.js
+++ b/test.js
@@ -30,7 +30,7 @@ test('isStream.writable()', t => {
 	t.false(isStream.writable(new Stream.Stream()));
 	t.false(isStream.writable(new Stream.Readable()));
 	t.false(isStream.writable(fs.createReadStream('test.js')));
-	t.false(isStream.writable(new net.Socket()));
+	t.true(isStream.writable(new net.Socket()));
 });
 
 test('isStream.readable()', t => {
@@ -42,7 +42,7 @@ test('isStream.readable()', t => {
 	t.false(isStream.readable(new Stream.Stream()));
 	t.false(isStream.readable(new Stream.Writable()));
 	t.false(isStream.readable(fs.createWriteStream(tempy.file())));
-	t.false(isStream.readable(new net.Socket()));
+	t.true(isStream.readable(new net.Socket()));
 });
 
 test('isStream.duplex()', t => {
@@ -52,6 +52,7 @@ test('isStream.duplex()', t => {
 	t.false(isStream.duplex(new Stream.Stream()));
 	t.false(isStream.duplex(new Stream.Readable()));
 	t.false(isStream.duplex(new Stream.Writable()));
+	t.true(isStream.writable(new net.Socket()));
 	t.false(isStream.duplex(fs.createReadStream('test.js')));
 	t.false(isStream.duplex(fs.createWriteStream(tempy.file())));
 });

--- a/test.js
+++ b/test.js
@@ -66,3 +66,20 @@ test('isStream.transform()', t => {
 	t.false(isStream.transform(fs.createReadStream('test.js')));
 	t.false(isStream.transform(fs.createWriteStream(tempy.file())));
 });
+
+test('isStream.type()', t => {
+	t.true(isStream.type(new Stream.Transform()) === 'transform');
+	t.true(isStream.type(new Stream.PassThrough()) === 'transform');
+	t.true(isStream.type(new Stream.Duplex()) === 'duplex');
+	t.true(isStream.type(new net.Socket()) === 'duplex');
+	t.true(isStream.type(new Stream.Readable()) === 'readable');
+	t.true(isStream.type(new Stream.Writable()) === 'writable');
+	t.true(isStream.type(new Stream.Stream()) === 'unknown');
+	t.true(isStream.type(fs.createReadStream('test.js')) === 'readable');
+	t.true(isStream.type(fs.createWriteStream(tempy.file())) === 'writable');
+	t.true(isStream.type({}) === 'no-stream');
+	t.true(isStream.type(null) === 'no-stream');
+	t.true(isStream.type(undefined) === 'no-stream');
+	t.true(isStream.type('') === 'no-stream');
+	t.true(isStream.type() === 'no-stream');
+});


### PR DESCRIPTION
Add support for return the type of stream 0f16638

Edit test.js, net.Socket() is a stream Duplex 620aeb1